### PR TITLE
ensure s3 cp is successfully executed

### DIFF
--- a/MonoToMicroAssets/MonoToMicroCF.template
+++ b/MonoToMicroAssets/MonoToMicroCF.template
@@ -376,10 +376,14 @@
 								"ASSETS_RANDOM_NAME=", {
 									"Ref": "AssetBucket"
 								}, "\n",
+								"declare -i EXIT_CODE=0\n",
 								"aws s3 cp /home/ec2-user/MonoToMicro/MonoToMicroUI s3://$UI_RANDOM_NAME/ --recursive --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers\n",
+								"EXIT_CODE+=$?\n",
 								"aws s3 cp /home/ec2-user/MonoToMicro/MonoToMicroLambda/build/libs s3://$ASSETS_RANDOM_NAME/ --recursive --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers\n",
+								"EXIT_CODE+=$?\n",
 								"java -jar /home/ec2-user/MonoToMicro/MonoToMicroLegacy/build/libs/MonoToMicroLegacy-0.0.1-SNAPSHOT.jar &\n",
-								"/opt/aws/bin/cfn-signal -e $?",
+								"EXIT_CODE+=$?\n",
+								"/opt/aws/bin/cfn-signal -e $EXIT_CODE",
 									" --stack ", { "Ref": "AWS::StackName" },
 									" --resource EC2Instance",
 									" --region ", { "Ref" : "AWS::Region" }, "\n"


### PR DESCRIPTION
For me the aws s3 cp commands failed as *Block public access setting* on account level was active but I haven't noticed that. This change ensures that the exit codes of both aws s3 cp commands are taken into account and used for the cfn-signal call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
