### PR TITLE
Setup Lambda CFN template

### DIFF
--- a/MonoToMicroAssets/MonoToMicroCFDDB.yaml
+++ b/MonoToMicroAssets/MonoToMicroCFDDB.yaml
@@ -18,6 +18,9 @@ Resources:
   LambdaRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: MonoToMicroLambdaRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -29,7 +32,7 @@ Resources:
               - sts:AssumeRole
       Path: /service-role/
       Policies:
-        - PolicyName: s3get
+        - PolicyName: LambdaDynamoDBAccess
           PolicyDocument:
             Version: 2012-10-17
             Statement:

--- a/MonoToMicroAssets/MonoToMicroLambda.yaml
+++ b/MonoToMicroAssets/MonoToMicroLambda.yaml
@@ -1,0 +1,42 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Amazon Lambda Services stack for the Application Modernization Workshop/Immersion Day
+Resources:
+  AddUnicornToBasketLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: AddUnicornToBasket
+      Description: Lambda that adds a unicorn into a basket.
+      Runtime: java11
+      MemorySize: 1024
+      Timeout: 30
+      Code:
+        S3Bucket: '{{resolve:ssm:LambdaAssetBucketName:1}}'
+        S3Key: MonoToMicroLambda-0.0.1.jar
+      Role: !Sub 'arn:aws:iam::${AWS::AccountId}:role/service-role/MonoToMicroLambdaRole'
+      Handler: com.monoToMicro.Lambda.UnicornBasketImpl::addUnicornToBasket
+  RemoveUnicornFromBasketLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: RemoveUnicornFromBasket
+      Description: Lambda that removes a unicorn from a basket.
+      Runtime: java11
+      MemorySize: 1024
+      Timeout: 30
+      Code:
+        S3Bucket: '{{resolve:ssm:LambdaAssetBucketName:1}}'
+        S3Key: MonoToMicroLambda-0.0.1.jar
+      Role: !Sub 'arn:aws:iam::${AWS::AccountId}:role/service-role/MonoToMicroLambdaRole'
+      Handler: com.monoToMicro.Lambda.UnicornBasketImpl::removeUnicornFromBasket
+  GetUnicornsBasketLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: GetUnicornsBasket
+      Description: Lambda that lists the unicorns in a basket.
+      Runtime: java11
+      MemorySize: 1024
+      Timeout: 30
+      Code:
+        S3Bucket: '{{resolve:ssm:LambdaAssetBucketName:1}}'
+        S3Key: MonoToMicroLambda-0.0.1.jar
+      Role: !Sub 'arn:aws:iam::${AWS::AccountId}:role/service-role/MonoToMicroLambdaRole'
+      Handler: com.monoToMicro.Lambda.UnicornBasketImpl::getUnicornsBasket


### PR DESCRIPTION
-  Added `AWSLambdaBasicExecutionRole` to the Lambda role to allow logging;
-  Created the CFN template to deploy the Lambda functions backing up the services;

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
