### PR TITLE
fix: adjust UI Bucket resource properties

### DIFF
--- a/MonoToMicroAssets/MonoToMicroCF.yaml
+++ b/MonoToMicroAssets/MonoToMicroCF.yaml
@@ -217,6 +217,14 @@ Resources:
       WebsiteConfiguration:
         ErrorDocument: error.html
         IndexDocument: index.html
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: true
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: true
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
   AssetBucket:
     Type: AWS::S3::Bucket
   EC2Instance:


### PR DESCRIPTION
*Issue #38 *

*Description of changes:*
- Adjusted UIBucket resource to allow ACLs to be used to enable S3 bucket to be used for hosting public frontend

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
